### PR TITLE
Implement logic for sending several photos as media group

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -28,11 +28,15 @@ def send_image(image_url, message_text=None):
 
 
 def send_media_group(media_urls):
+    input_media_list = list()
+    for url in media_urls:
+        input_media_list.append({'type':'photo','media':url})
     url = 'https://api.telegram.org/bot' + config.telegram_token + '/sendMediaGroup'
     parameters = {'chat_id': config.chat_id,
-                  'media': json.dumps(media_urls)}
+                  'media': json.dumps(input_media_list)}
     r = get(url, params=parameters)
     return r
+
 
 if __name__ == '__main__':
     posted_records_hashes = []
@@ -49,11 +53,11 @@ if __name__ == '__main__':
                     if len(wall_record_data['images']) > 1:
                         send_media_group(wall_record_data['images'])
                         continue
-                    if len(message_text) > 200:
-                        send_image(wall_record_data['images'])
-                    else:
+                    if len(message_text) < 200:
                         send_image(wall_record_data['images'], message_text)
                         continue
+                    else:
+                        send_image(wall_record_data['images'])
                 send_message(message_text)
         if len(posted_records_hashes) > 100:
             del posted_records_hashes[0]

--- a/vk_wall_listener.py
+++ b/vk_wall_listener.py
@@ -26,7 +26,6 @@ def get_data_from_record(record):
         for attachment in record['attachments']:
             if attachment['type'] == 'photo':
                attachments.append(attachment['photo']['src_big'])
-
         result['images']=attachments
     except KeyError:
         pass


### PR DESCRIPTION
To send several photos as album they should be packed as array of [InputMediaPhoto type](https://core.telegram.org/bots/api#inputmediaphoto) and given as parameter "media" to [sendMediaGroup API call](https://core.telegram.org/bots/api#sendmediagroup)